### PR TITLE
Fix table markup and add ALSA device name for Hercules Mk2

### DIFF
--- a/_data/soundcards.yml
+++ b/_data/soundcards.yml
@@ -43,15 +43,15 @@
 
 - name: Hercules DJ Console Mk2
   alsa_device_names:
-    - ???
+    - plughw:Mk2,0,0
   links:
     - http://www.hercules.com/uk/legacy/bdd/p/12/dj-console-mk2-virtualdj-djc-ed/
   tested_on:
-    - Debian Squeeze
+    - Debian Jessie
   comments: |
     Requires a high output cartridge such as Shure M44-7 (9.5mV) to work well,
     Pickering 625-DJ (3mV) was not loud enough. Set Headphones Selection knob
-    to Deck B to isolate output for second deck on phono outputs 3 and 4.
+    to Deck B to isolate output for second deck on RCA socket outputs 3 and 4.
 
 
 - name: Native Instruments Audio 4 DJ

--- a/keyboard_control.md
+++ b/keyboard_control.md
@@ -5,7 +5,8 @@ title: Keyboard Controls
 
 ## Library Controls
 
-^  Key  ^  Function  ^
+| Key  |  Function  |
+| --- | --- |
 | Up\\ Down  | Scrolls through the library  |
 |Page Up\\ Page Down  | Scrolls through the library one page at a time  |
 |Left\\ Right  | Scrolls through the directories specified at startup  |
@@ -20,8 +21,9 @@ You can also search through your library by typing your desired search term, jus
 
 Deck control in xwax is done via the function keys. F1 - F4 control deck 0, F5 - F8 control deck 1 and F9 - F12 control deck 2.
 
-^  Key  ^^^  Function  ^
-^ Deck 0  ^ Deck 1  ^ Deck 2  ^	::: ^
+|  Key  |  Key  |  Key  |  Function  |
+|  ---  |  ---  |  ---  ||
+| Deck 0  | Deck 1  | Deck 2  ||
 | F1  |F5  | F9  | Load currently selected track to this deck  |
 | F2  |F6  | F10  | Set current position on the record to 0.00 on the virtual deck  |
 | F3  |F7  | F11  | Toggle timecode control on/off  |
@@ -32,8 +34,9 @@ Deck control in xwax is done via the function keys. F1 - F4 control deck 0, F5 -
 
 Instant doubles is an "undocumented feature". It doesn't officially exist and may be removed or altered in future.
 
-^  Key  ^^^  Function  ^
-^ Deck 0  ^ Deck 1  ^ Deck 2  ^	::: ^
+|  Key  |  Key  |  Key  |  Function  |
+|  ---  |  ---  |  ---  ||
+| Deck 0  | Deck 1  | Deck 2  ||
 |  -  | Shift-F5  | Shift-F9  | Clone deck 0 into current deck  |
 | Shift-F2  |  -  | Shift-F10  | Clone deck 1 into current deck  |
 | Shift-F3  | Shift-F7  |  -  | Clone deck 2 into current deck  |
@@ -41,6 +44,7 @@ Instant doubles is an "undocumented feature". It doesn't officially exist and ma
 
 ## Miscellaneous Controls
 
-^  Key  ^  Function  ^
+|  Key  |  Function  |
+|  ---  |  ---  |
 | =  | Zoom in waveform  |
 | -  | Zoom out waveform  |

--- a/novation_dicer_control.md
+++ b/novation_dicer_control.md
@@ -25,7 +25,8 @@ The Dicer has 3 different modes, selected by the three small buttons on the cont
 
 Buttons with a cue point set to them are lit, those without are dimmed.
 
-^  Mode  ^  Button  ^  Function  ^
+|  Mode  |  Button  |  Function  |
+|  ---   |  ---     |  ---       |
 | Cue | Dice Button | Jump to the specified cue point, or set it if unset. |
 | ::: | Dice Button + Mode Button | Unset the specified cue point |
 | Punch | Dice Button | "Punch" to the specified cue point, or set it if unset. Returns playback to normal when the button is released, much like slip-mode on Pioneer CDJs. |


### PR DESCRIPTION
Tables aren't currently being rendered on http://wiki.xwax.org/keyboard_control and http://wiki.xwax.org/novation_dicer_control pages. This markup change should fix that.
