### PR TITLE
Add default scan location add .m4a compatibility via AtomicParsely

### DIFF
--- a/mark_scan_tags.md
+++ b/mark_scan_tags.md
@@ -15,8 +15,10 @@ PATHNAME="$1"
 
 if [ -x /usr/local/libexec/xwax-scan ]; then
 	SCAN=/usr/local/libexec/xwax-scan
-else
+elif [ -x /usr/libexec/xwax-scan ]; then
 	SCAN=/usr/libexec/xwax-scan
+else
+	SCAN=/usr/share/xwax/xwax-scan
 fi
 
 if [ -d "$PATHNAME" ] && [ -w "$PATHNAME" ]; then
@@ -47,6 +49,9 @@ IFS=$'\t'
 		;;
 	*.ogg)
 		BPM=`vorbiscomment "$FILE" | sed -n 's/^BPM=//p' | tail -1l`
+		;;
+	*.m4a)
+		BPM=`AtomicParsley "$FILE" -t 2>/dev/null | sed -n -E 's/Atom "tmpo" contains: *([0-9]+).*/\1/p'`
 		;;
 	esac
 


### PR DESCRIPTION
This PR adds two improvements to Mark's scan scrtipt:

## 1. Support for Debian/Ubuntu package installation path
- Adds `/usr/share/xwax/xwax-scan` to the search paths
- Supports users who install via `sudo apt install xwax` on Debian-based systems
- **Sources:**
  - Official Debian package file list: https://packages.debian.org/sid/amd64/xwax/filelist  
  - Official xwax wiki: https://wiki.xwax.org/debian_installation

## 2. M4A file scanning support
- Adds AtomicParsley support for M4A files
- Expands format compatibility for users with M4A audio libraries